### PR TITLE
feat(bazaar): Endorse Main Menu instead of Pins in Curated section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 ## Bluefin 
 *Deinonychus antirrhopus*
 
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2503a44c1105456483517f793af75ee7)](https://app.codacy.com/gh/ublue-os/bluefin/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade) [![GTS Images](https://github.com/ublue-os/bluefin/actions/workflows/build-image-gts.yml/badge.svg)](https://github.com/ublue-os/bluefin/actions/workflows/build-image-gts.yml)[![Stable Images](https://github.com/ublue-os/bluefin/actions/workflows/build-image-stable.yml/badge.svg)](https://github.com/ublue-os/bluefin/actions/workflows/build-image-stable.yml)[![Latest Images](https://github.com/ublue-os/bluefin/actions/workflows/build-image-latest-main.yml/badge.svg)](https://github.com/ublue-os/bluefin/actions/workflows/build-image-latest-main.yml)[![Latest Images HWE](https://github.com/ublue-os/bluefin/actions/workflows/build-image-latest-hwe.yml/badge.svg)](https://github.com/ublue-os/bluefin/actions/workflows/build-image-latest-hwe.yml)[![Beta Images](https://github.com/ublue-os/bluefin/actions/workflows/build-image-beta.yml/badge.svg)](https://github.com/ublue-os/bluefin/actions/workflows/build-image-beta.yml)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ublue-os/bluefin)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2503a44c1105456483517f793af75ee7)](https://app.codacy.com/gh/ublue-os/bluefin/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade) [![GTS Images](https://github.com/ublue-os/bluefin/actions/workflows/build-image-gts.yml/badge.svg)](https://github.com/ublue-os/bluefin/actions/workflows/build-image-gts.yml)[![Stable Images](https://github.com/ublue-os/bluefin/actions/workflows/build-image-stable.yml/badge.svg)](https://github.com/ublue-os/bluefin/actions/workflows/build-image-stable.yml)[![Latest Images](https://github.com/ublue-os/bluefin/actions/workflows/build-image-latest-main.yml/badge.svg)](https://github.com/ublue-os/bluefin/actions/workflows/build-image-latest-main.yml)
 
-> "Evolution is a process of constant branching and expansion." - Stephen Jay Gould
+![Bluefin Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json)
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ublue-os/bluefin)
 
 For end users it provides a system as reliable as a Chromebook with near-zero maintainance. For developers, a powerful cloud native developer workflow. Check [Introduction to Bluefin](https://docs.projectbluefin.io/introduction/) for a feature walkthrough.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2503a44c1105456483517f793af75ee7)](https://app.codacy.com/gh/ublue-os/bluefin/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade) [![GTS Images](https://github.com/ublue-os/bluefin/actions/workflows/build-image-gts.yml/badge.svg)](https://github.com/ublue-os/bluefin/actions/workflows/build-image-gts.yml)[![Stable Images](https://github.com/ublue-os/bluefin/actions/workflows/build-image-stable.yml/badge.svg)](https://github.com/ublue-os/bluefin/actions/workflows/build-image-stable.yml)[![Latest Images](https://github.com/ublue-os/bluefin/actions/workflows/build-image-latest-main.yml/badge.svg)](https://github.com/ublue-os/bluefin/actions/workflows/build-image-latest-main.yml)
 
-![Bluefin Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json)
+![Bluefin Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json&label=Weekly%20Device%20Count)
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ublue-os/bluefin)
 

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -2,4 +2,4 @@ images:
   - name: silverblue-main
     image: ghcr.io/ublue-os/silverblue-main
     tag: latest
-    digest: sha256:4c589fc18bbf4ae21868dfa22b74addb7c087fd6f2b17c4b224956a63d1e4259
+    digest: sha256:ac7bf97822224026a2058e0b1b18f6988e7e4d062f5c73add75ce51bbc38ec7b

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -2,4 +2,4 @@ images:
   - name: silverblue-main
     image: ghcr.io/ublue-os/silverblue-main
     tag: latest
-    digest: sha256:ac7bf97822224026a2058e0b1b18f6988e7e4d062f5c73add75ce51bbc38ec7b
+    digest: sha256:ec394b6c6debdfe6b7847d17f5a812fa1afae61ce31d2715d7d3774a21522f64

--- a/packages.json
+++ b/packages.json
@@ -205,7 +205,7 @@
 		},
 		"exclude": {
 			"all": [
-  				"gnome-software",		
+  				"gnome-software"		
 			],
 			"dx": []
 		}

--- a/packages.json
+++ b/packages.json
@@ -170,7 +170,6 @@
 				"firefox-langpacks",
 				"gnome-extensions-app",
 				"gnome-shell-extension-background-logo",
-				"gnome-software",
 				"gnome-software-rpm-ostree",
 				"gnome-terminal-nautilus",
 				"podman-docker",
@@ -189,7 +188,9 @@
 			"dx": []
 		},
 		"exclude": {
-			"all": [],
+			"all": [
+
+			],
 			"dx": []
 		}
 	},
@@ -203,7 +204,9 @@
 			"dx": []
 		},
 		"exclude": {
-			"all": [],
+			"all": [
+  				"gnome-software",		
+			],
 			"dx": []
 		}
 	}

--- a/system_files/shared/usr/share/ublue-os/bazaar/blocklist.txt
+++ b/system_files/shared/usr/share/ublue-os/bazaar/blocklist.txt
@@ -1,3 +1,4 @@
+app.devsuite.Ptyxis
 com.visualstudio.code
 com.visualstudio.code-oss
 com.vscodium.codium

--- a/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -55,7 +55,7 @@ sections:
       - bazzite-section
     appids:
       - re.sonny.Eloquent
-      - io.github.fabrialberio.pinapp
+      - page.codeberg.libre_menu_editor.LibreMenuEditor
       - app.fotema.Fotema
       - be.alexandervanhee.gradia
       - app.drey.Damask

--- a/system_files/shared/usr/share/ublue-os/motd/template.md
+++ b/system_files/shared/usr/share/ublue-os/motd/template.md
@@ -9,7 +9,7 @@
 | `ujust bluefin-cli` | Enable terminal bling | 
 | `brew help` | Manage command line packages | 
 
-%TIP%
+Donate to [Bazaar](https://github.com/kolunmi/bazaar), the next generation app store for Flathub!
 
 - **󰊤** [Issues](https://issues.projectbluefin.io)
 - **󰈙** [Documentation](http://docs.projectbluefin.io/)

--- a/system_files/shared/usr/share/ublue-os/motd/tips/10-tips.md
+++ b/system_files/shared/usr/share/ublue-os/motd/tips/10-tips.md
@@ -1,5 +1,5 @@
 Bluefin is your gateway to Cloud Native - find your flock at [landscape.cncf.io](https://l.cncf.io)
-Support the app store! Donate to  [Flatpak](https://opencollective.com/flatpak)
+Support the app store! Donate to  [Bazaar](https://github.com/kolunmi/bazaar)!
 Need more indepth technical information?~Check out the [Bluefin Administrator's Guide](https://docs.projectbluefin.io/administration)
 Like servers? Check out [ucore](https://github.com/ublue-os/ucore)
 Update break something? You can roll back with `sudo bootc rollback`


### PR DESCRIPTION
I propose endorsing Main Menu instead of Pins in the curated section of Bazaar.

Main Menu allows users to customize their app launchers. While both Pins and Main Menu are under the hood just frontends editing .desktop files, Main Menu removes foot guns by not letting the user just edit keys and values and instead exposing approachable settings.

Check out Main Menu: https://flathub.org/apps/page.codeberg.libre_menu_editor.LibreMenuEditor

I'm not affiliated with Main Menu, I'm just a happy user.